### PR TITLE
refactor: move browser specific logic to conditionally run and enable ssr again

### DIFF
--- a/client/src/+layout.ts
+++ b/client/src/+layout.ts
@@ -1,1 +1,0 @@
-export const ssr = false;

--- a/client/src/lib/auth.store.ts
+++ b/client/src/lib/auth.store.ts
@@ -1,6 +1,7 @@
 import { goto } from '$app/navigation';
 import { writable } from 'svelte/store';
 import { redirect } from '@sveltejs/kit';
+import { browser } from '$app/environment';
 
 import { getAuthState, authenticate, setAuthState } from './auth';
 
@@ -8,28 +9,33 @@ type AuthState = {
 	userId: string;
 	secretCode: string;
 };
-export const authState = writable<AuthState | null>(getAuthState());
+
+export const authState = writable<AuthState | null>(null);
 
 authState.subscribe((v) => {
-	setAuthState(v);
+	if (browser) {
+		setAuthState(v);
 
-	if (v === null) {
-		goto('/login');
+		if (v === null) {
+			goto('/login');
+		}
 	}
 });
 
-export async function initAuth() {
-	const localStorageAuthState = getAuthState();
+export async function initAuth () {
+	if (browser) {
+		const localStorageAuthState = getAuthState();
 
-	if (localStorageAuthState === null) return;
+		if (localStorageAuthState === null) return;
 
-	await authenticate(localStorageAuthState.userId, localStorageAuthState.secretCode, {
-		onSuccess: async () => {
-			authState.set(localStorageAuthState);
-		},
-		onError: async () => {
-			authState.set(null);
-			throw redirect(300, '/login');
-		}
-	});
+		await authenticate(localStorageAuthState.userId, localStorageAuthState.secretCode, {
+			onSuccess: async () => {
+				authState.set(localStorageAuthState);
+			},
+			onError: async () => {
+				authState.set(null);
+				throw redirect(303, '/login');
+			}
+		});
+	}
 }

--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -1,3 +1,4 @@
+import { browser } from '$app/environment';
 import { redirect } from '@sveltejs/kit';
 
 type AuthState = {
@@ -8,6 +9,7 @@ type AuthState = {
 const AUTH_STATE_KEY = 'AUTH_STATE';
 
 export function getAuthState() {
+	if(!browser) return null; 
 	const stored = localStorage.getItem(AUTH_STATE_KEY);
 	if (stored === null) return null;
 	else return JSON.parse(stored) as AuthState;
@@ -17,7 +19,7 @@ export function getAuthToken() {
 	const auth = getAuthState();
 
 	if (auth === null) {
-		throw redirect(300, '/login');
+		throw redirect(303, '/login');
 	}
 
 	return btoa(`${auth.userId}:${auth.secretCode}`);

--- a/client/src/routes/+layout.svelte
+++ b/client/src/routes/+layout.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
 	import './styles.css';
 	import { authState, initAuth } from '$lib/auth.store';
+	import { onMount } from 'svelte';
 
-	initAuth();
+	onMount(() => {
+		initAuth();
+	});
+
 </script>
 
 <section>


### PR DESCRIPTION
Tried starting this locally but ssr was causing issues (specifically localStorage being access on the server side where it is only apart of the browser API). 
This PR enables site wide ssr again and conditionally use browser specific functions only in the browser